### PR TITLE
exa->eza and lua_ls rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,6 @@ Some of the plugins have a unique configuration, some of them just copied config
 
   Rainbow parentheses for neovim using tree-sitter. Also at https://sr.ht/~p00f/nvim-ts-rainbow
 
-- [`alpha-nvim`](https://github.com/goolord/alpha-nvim) for greeter page:
-
-  a lua powered greeter like vim-startify / dashboard-nvim
-
 - [`indent-blankline.nvim`](https://github.com/lukas-reineke/indent-blankline.nvim) for coloring indent blankline:
 
   Indent guides for Neovim

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We want to create an awesome Development Environment's so a big part of this doc
   It is a user-friendly command-line shell.
 
   [It's my `config.fish`](https://raw.githubusercontent.com/hemedani/dotfiles/main/config.fish), you should put it in `$HOME/.config/fish/config.fish`:
-  please note that you should be install [`exa`](https://github.com/ogham/exa) [`zoxide`](https://github.com/ajeetdsouza/zoxide) and [`starship`](https://github.com/starship/starship) to avoid throwing error for `functions` and `init` command in the config file
+  please note that you should be install [`eza`](https://github.com/eza-community/eza) [`zoxide`](https://github.com/ajeetdsouza/zoxide) and [`starship`](https://github.com/starship/starship) to avoid throwing error for `functions` and `init` command in the config file
 
 - [Using `starship` as your default Shell prompt.](https://github.com/starship/starship)
 
@@ -86,15 +86,15 @@ We want to create an awesome Development Environment's so a big part of this doc
 
   [It's my `GitUI` `VIM Like` keybinding](https://raw.githubusercontent.com/hemedani/dotfiles/main/gitui/key_bindings.ron), you should put it in `$HOME/.config/gitui/key_bindings.ron`
 
-- Using [`exa`](https://github.com/ogham/exa) as a `ls` command in the terminal:
+- Using [`eza`](https://github.com/eza-community/eza) as a `ls` command in the terminal:
 
   A modern replacement for ‘ls’.
 
-  I personally set `ll` alias to `exa --tree --level=2 -a --long --header --accessed` with this functions in `fish` shell:
+  I personally set `ll` alias to `eza --tree --level=2 -a --long --header --accessed` with this functions in `fish` shell:
 
   ```fish
-  function ll --wraps=ls --wraps=exa --description 'List contents of directory using exa tree'
-      exa --tree --level=2 -a --long --header --accessed --git $argv
+  function ll --wraps=ls --wraps=eza --description 'List contents of directory using eza tree'
+      eza --tree --level=2 -a --long --header --accessed --git $argv
   end
   ```
 

--- a/lua/lsp/config/s-lua.lua
+++ b/lua/lsp/config/s-lua.lua
@@ -18,7 +18,7 @@ local runtime_path = vim.split(package.path, ";")
 table.insert(runtime_path, "lua/?.lua")
 table.insert(runtime_path, "lua/?/init.lua")
 
-require("lspconfig").sumneko_lua.setup({
+require("lspconfig").lua_ls.setup({
 	cmd = { sumneko_binary, "-E", sumneko_root_path .. "/main.lua" },
 	on_attach = require("lsp.lsp-attach").on_attach,
 	settings = {


### PR DESCRIPTION
Hi, 

I have made some minor updates:

- [exa](https://github.com/ogham/exa) is now unmaintained and has been replaced with [eza](https://github.com/eza-community/eza) 
- As per [this PR](https://github.com/neovim/nvim-lspconfig/pull/2439), sumneko_lua has been renamed to lua_ls
- alpha-nvim was listed twice in the readme, fixed